### PR TITLE
mulitconfig: add MustLoad and MustLoadWithPath

### DIFF
--- a/multiconfig.go
+++ b/multiconfig.go
@@ -3,6 +3,7 @@ package multiconfig
 import (
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -71,10 +72,25 @@ func New() *DefaultLoader {
 	return d
 }
 
+// MustLoadWithPath loads with the DefaultLoader settings and from the given
+// Path. It exits if the config cannot be parsed.
+func MustLoadWithPath(path string, conf interface{}) {
+	d := NewWithPath(path)
+	d.MustLoad(conf)
+}
+
+// MustLoad loads with the DefaultLoader settings. It exits if the config
+// cannot be parsed.
+func MustLoad(conf interface{}) {
+	d := New()
+	d.MustLoad(conf)
+}
+
 // MustLoad is like Load but panics if the config cannot be parsed.
 func (d *DefaultLoader) MustLoad(conf interface{}) {
 	if err := d.Load(conf); err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 
 	// we at koding, believe having sane defaults in our system, this is the
@@ -85,10 +101,12 @@ func (d *DefaultLoader) MustLoad(conf interface{}) {
 	}
 }
 
-// MustValidate validates the struct or panics
+// MustValidate validates the struct. It exits with status 1 if it can't
+// validate.
 func (d *DefaultLoader) MustValidate(conf interface{}) {
 	if err := d.Validate(conf); err != nil {
-		panic(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 }
 

--- a/validator.go
+++ b/validator.go
@@ -65,7 +65,7 @@ func (e *RequiredValidator) processField(fieldName string, field *structs.Field)
 		}
 
 		if field.IsZero() {
-			return fmt.Errorf("field %s is required", fieldName)
+			return fmt.Errorf("multiconfig: field '%s' is required", fieldName)
 		}
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -43,7 +43,7 @@ func TestValidatorsCustomTag(t *testing.T) {
 		t.Fatal("Port should be required")
 	}
 
-	errStr := "field Postgres.Port is required"
+	errStr := "multiconfig: field 'Postgres.Port' is required"
 	if err.Error() != errStr {
 		t.Fatalf("Err string is wrong: expected %s, got: %s", errStr, err.Error())
 	}


### PR DESCRIPTION
We can now use `multiconfig.MustLoad()` instead of the ugly `multiconfig.New().MustLoad(conf)`