### PR TITLE
flag: expose Args for flexibility

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -23,8 +23,8 @@ type FlagLoader struct {
 	// EnvLoader is used
 	EnvPrefix string
 
-	// args defines a custom argument list that overides os.Args[]
-	args []string
+	// Args defines a custom argument list. If nil, os.Args[1:] is used.
+	Args []string
 }
 
 // Load loads the source into the config defined by struct s
@@ -48,8 +48,8 @@ func (f *FlagLoader) Load(s interface{}) error {
 	}
 
 	args := os.Args[1:]
-	if f.args != nil {
-		args = f.args
+	if f.Args != nil {
+		args = f.Args
 	}
 
 	return flagSet.Parse(args)

--- a/flag_test.go
+++ b/flag_test.go
@@ -15,7 +15,7 @@ func TestFlag(t *testing.T) {
 	// get flags
 	args := getFlags(t, structName, "")
 
-	m.args = args[1:]
+	m.Args = args[1:]
 
 	if err := m.Load(s); err != nil {
 		t.Error(err)
@@ -34,7 +34,7 @@ func TestFlagWithPrefix(t *testing.T) {
 	// get flags
 	args := getFlags(t, structName, prefix)
 
-	m.args = args[1:]
+	m.Args = args[1:]
 
 	if err := m.Load(s); err != nil {
 		t.Error(err)


### PR DESCRIPTION
This makes the flag loader more powerful. We can only pass certain
arguments and it would still work with the other loaders.