### PR TITLE
Flattened flags

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -75,19 +75,16 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 
 			if f.Flatten {
 				// first check if it's set or not, because if we have duplicate
-				// we don't want to break the flag. Just let the user fix it
-				// (by adding the fixme prefix)
-				alreadyDefined := false
+				// we don't want to break the flag. Panic by giving a readable
+				// output
 				flagSet.VisitAll(func(fl *flag.Flag) {
 					if strings.ToLower(ff.Name()) == fl.Name {
-						alreadyDefined = true
+						// already defined
+						panic(fmt.Sprintf("flag '%s' is already defined in outer struct", fl.Name))
 					}
 				})
 
 				flagName = ff.Name()
-				if alreadyDefined {
-					flagName = "fixme-" + ff.Name()
-				}
 			}
 
 			if err := f.processField(flagSet, flagName, ff); err != nil {

--- a/flag.go
+++ b/flag.go
@@ -19,6 +19,15 @@ type FlagLoader struct {
 	// --foo-bar is converted to --prefix-foo-bar.
 	Prefix string
 
+	// Flatten doesn't add prefixes for nested structs. So previously if we had
+	// a nested struct `type T struct{Name struct{ ...}}`, this would generate
+	// --name-foo, --name-bar, etc. When Flatten is enabled, the flags will be
+	// flattend to the form: --foo, --bar, etc.. If the nested structs has a
+	// duplicate field name in the root level of the struct, it needs to be
+	// fixed and it will be displayed as --fixme-foo. Use this option only if
+	// you know what you do.
+	Flatten bool
+
 	// EnvPrefix is just a placeholder to print the correct usages when an
 	// EnvLoader is used
 	EnvPrefix string
@@ -62,7 +71,26 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 	switch field.Kind() {
 	case reflect.Struct:
 		for _, ff := range field.Fields() {
-			if err := f.processField(flagSet, field.Name()+"-"+ff.Name(), ff); err != nil {
+			flagName := field.Name() + "-" + ff.Name()
+
+			if f.Flatten {
+				// first check if it's set or not, because if we have duplicate
+				// we don't want to break the flag. Just let the user fix it
+				// (by adding the fixme prefix)
+				alreadyDefined := false
+				flagSet.VisitAll(func(fl *flag.Flag) {
+					if flagName == fl.Name {
+						alreadyDefined = true
+					}
+				})
+
+				flagName = ff.Name()
+				if alreadyDefined {
+					flagName = "fixme-" + ff.Name()
+				}
+			}
+
+			if err := f.processField(flagSet, flagName, ff); err != nil {
 				return err
 			}
 		}

--- a/flag.go
+++ b/flag.go
@@ -22,10 +22,9 @@ type FlagLoader struct {
 	// Flatten doesn't add prefixes for nested structs. So previously if we had
 	// a nested struct `type T struct{Name struct{ ...}}`, this would generate
 	// --name-foo, --name-bar, etc. When Flatten is enabled, the flags will be
-	// flattend to the form: --foo, --bar, etc.. If the nested structs has a
-	// duplicate field name in the root level of the struct, it needs to be
-	// fixed and it will be displayed as --fixme-foo. Use this option only if
-	// you know what you do.
+	// flattend to the form: --foo, --bar, etc.. Panics if the nested structs
+	// has a duplicate field name in the root level of the struct (outer
+	// struct). Use this option only if you know what you do.
 	Flatten bool
 
 	// EnvPrefix is just a placeholder to print the correct usages when an

--- a/flag.go
+++ b/flag.go
@@ -79,7 +79,7 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 				// (by adding the fixme prefix)
 				alreadyDefined := false
 				flagSet.VisitAll(func(fl *flag.Flag) {
-					if flagName == fl.Name {
+					if strings.ToLower(ff.Name()) == fl.Name {
 						alreadyDefined = true
 					}
 				})

--- a/flag_test.go
+++ b/flag_test.go
@@ -86,7 +86,6 @@ func getFlags(t *testing.T, structName, prefix string) []string {
 		flags = map[string]string{
 			"--enabled":           "",
 			"--port":              "5432",
-			"--fixme-port":        "5432",
 			"--hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"--dbname":            "configdb",
 			"--availabilityratio": "8.23",

--- a/flag_test.go
+++ b/flag_test.go
@@ -86,6 +86,7 @@ func getFlags(t *testing.T, structName, prefix string) []string {
 		flags = map[string]string{
 			"--enabled":           "",
 			"--port":              "5432",
+			"--fixme-port":        "5432",
 			"--hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"--dbname":            "configdb",
 			"--availabilityratio": "8.23",

--- a/flag_test.go
+++ b/flag_test.go
@@ -43,22 +43,53 @@ func TestFlagWithPrefix(t *testing.T) {
 	testStruct(t, s, getDefaultServer())
 }
 
+func TestFlattenFlags(t *testing.T) {
+	m := FlagLoader{
+		Flatten: true,
+	}
+	s := &FlattenedServer{}
+	structName := structs.Name(s)
+
+	// get flags
+	args := getFlags(t, structName, "")
+
+	m.Args = args[1:]
+
+	if err := m.Load(s); err != nil {
+		t.Error(err)
+	}
+
+	testFlattenedStruct(t, s, getDefaultServer())
+}
+
 // getFlags returns a slice of arguments that can be passed to flag.Parse()
 func getFlags(t *testing.T, structName, prefix string) []string {
 	if structName == "" {
 		t.Fatal("struct name can not be empty")
 	}
 
-	flags := map[string]string{
-		"-name":                       "koding",
-		"-port":                       "6060",
-		"-enabled":                    "",
-		"-users":                      "ankara,istanbul",
-		"-postgres-enabled":           "",
-		"-postgres-port":              "5432",
-		"-postgres-hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
-		"-postgres-dbname":            "configdb",
-		"-postgres-availabilityratio": "8.23",
+	var flags map[string]string
+	switch structName {
+	case "Server":
+		flags = map[string]string{
+			"-name":                       "koding",
+			"-port":                       "6060",
+			"-enabled":                    "",
+			"-users":                      "ankara,istanbul",
+			"-postgres-enabled":           "",
+			"-postgres-port":              "5432",
+			"-postgres-hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
+			"-postgres-dbname":            "configdb",
+			"-postgres-availabilityratio": "8.23",
+		}
+	case "FlattenedServer":
+		flags = map[string]string{
+			"--enabled":           "",
+			"--port":              "5432",
+			"--hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
+			"--dbname":            "configdb",
+			"--availabilityratio": "8.23",
+		}
 	}
 
 	prefix = strings.ToLower(prefix)

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -22,7 +22,6 @@ type (
 )
 
 type FlattenedServer struct {
-	Port     int // fixme flag case
 	Postgres Postgres
 }
 

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -21,6 +21,10 @@ type (
 	}
 )
 
+type FlattenedServer struct {
+	Postgres Postgres
+}
+
 var (
 	testTOML = "testdata/config.toml"
 	testJSON = "testdata/config.json"
@@ -99,6 +103,37 @@ func testStruct(t *testing.T, s *Server, d *Server) {
 		}
 	}
 
+	// Explicitly state that Enabled should be true, no need to check
+	// `x == true` infact.
+	if s.Postgres.Enabled != d.Postgres.Enabled {
+		t.Errorf("Postgres enabled is wrong %t, want: %t", s.Postgres.Enabled, d.Postgres.Enabled)
+	}
+
+	if s.Postgres.Port != d.Postgres.Port {
+		t.Errorf("Postgres Port value is wrong: %d, want: %d", s.Postgres.Port, d.Postgres.Port)
+	}
+
+	if s.Postgres.DBName != d.Postgres.DBName {
+		t.Errorf("DBName is wrong: %s, want: %s", s.Postgres.DBName, d.Postgres.DBName)
+	}
+
+	if s.Postgres.AvailabilityRatio != d.Postgres.AvailabilityRatio {
+		t.Errorf("AvailabilityRatio is wrong: %f, want: %f", s.Postgres.AvailabilityRatio, d.Postgres.AvailabilityRatio)
+	}
+
+	if len(s.Postgres.Hosts) != len(d.Postgres.Hosts) {
+		// do not continue testing if this fails, because others is depending on this test
+		t.Fatalf("Hosts len is wrong: %v, want: %v", s.Postgres.Hosts, d.Postgres.Hosts)
+	}
+
+	for i, host := range d.Postgres.Hosts {
+		if s.Postgres.Hosts[i] != host {
+			t.Fatalf("Hosts number %d is wrong: %v, want: %v", i, s.Postgres.Hosts[i], host)
+		}
+	}
+}
+
+func testFlattenedStruct(t *testing.T, s *FlattenedServer, d *Server) {
 	// Explicitly state that Enabled should be true, no need to check
 	// `x == true` infact.
 	if s.Postgres.Enabled != d.Postgres.Enabled {

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -22,6 +22,7 @@ type (
 )
 
 type FlattenedServer struct {
+	Port     int // fixme flag case
 	Postgres Postgres
 }
 


### PR DESCRIPTION
Flatten doesn't add prefixes for nested structs. So previously if we had
a nested struct `type T struct{Name struct{ ...}}`, this would generate
--name-foo, --name-bar, etc. When Flatten is enabled, the flags will be
flattend to the form: --foo, --bar, etc.. If the nested structs has a
duplicate field name in the root level of the struct, it needs to be
fixed ~~and it will be displayed as --fixme-foo~~ otherwise panics. 

This is again needed to have more control over the flags when using multiconfig with other applications :)