### PR TITLE
Add CamelCase option, to create separated env and flag names

### DIFF
--- a/env.go
+++ b/env.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/fatih/camelcase"
 	"github.com/fatih/structs"
 )
 
@@ -16,6 +17,12 @@ type EnvironmentLoader struct {
 	// Prefix prepends given string to every environment variable
 	// {STRUCTNAME}_FIELDNAME will be {PREFIX}_FIELDNAME
 	Prefix string
+
+	// CamelCase adds a seperator for field names in camelcase form. A
+	// fieldname of "AccessKey" would generate a environment name of
+	// "STRUCTNAME_ACCESSKEY". If CamelCase is enabled, the environment name
+	// will be generated in the form of "STRUCTNAME_ACCESS_KEY"
+	CamelCase bool
 }
 
 func (e *EnvironmentLoader) getPrefix(s *structs.Struct) string {
@@ -92,8 +99,13 @@ func (e *EnvironmentLoader) printField(prefix string, field *structs.Field) {
 	}
 }
 
-// generateFieldName generates the fiels name conbined with the prefix and the
+// generateFieldName generates the fiels name combined with the prefix and the
 // struct's field name
 func (e *EnvironmentLoader) generateFieldName(prefix string, field *structs.Field) string {
-	return strings.ToUpper(prefix) + "_" + strings.ToUpper(field.Name())
+	fieldName := strings.ToUpper(field.Name())
+	if e.CamelCase {
+		fieldName = strings.ToUpper(strings.Join(camelcase.Split(field.Name()), "_"))
+	}
+
+	return strings.ToUpper(prefix) + "_" + fieldName
 }

--- a/env_test.go
+++ b/env_test.go
@@ -23,6 +23,23 @@ func TestENV(t *testing.T) {
 	testStruct(t, s, getDefaultServer())
 }
 
+func TestCamelCaseEnv(t *testing.T) {
+	m := EnvironmentLoader{
+		CamelCase: true,
+	}
+	s := &CamelCaseServer{}
+	structName := structs.Name(s)
+
+	// set env variables
+	setEnvVars(t, structName, "")
+
+	if err := m.Load(s); err != nil {
+		t.Error(err)
+	}
+
+	testCamelcaseStruct(t, s, getDefaultCamelCaseServer())
+}
+
 func TestENVWithPrefix(t *testing.T) {
 	const prefix = "Prefix"
 
@@ -45,17 +62,28 @@ func setEnvVars(t *testing.T, structName, prefix string) {
 		t.Fatal("struct name can not be empty")
 	}
 
-	env := map[string]string{
-		"NAME":                       "koding",
-		"PORT":                       "6060",
-		"ENABLED":                    "true",
-		"USERS":                      "ankara,istanbul",
-		"POSTGRES_ENABLED":           "true",
-		"POSTGRES_PORT":              "5432",
-		"POSTGRES_HOSTS":             "192.168.2.1,192.168.2.2,192.168.2.3",
-		"POSTGRES_DBNAME":            "configdb",
-		"POSTGRES_AVAILABILITYRATIO": "8.23",
-		"POSTGRES_FOO":               "8.23,9.12,11,90",
+	var env map[string]string
+	switch structName {
+	case "Server":
+		env = map[string]string{
+			"NAME":                       "koding",
+			"PORT":                       "6060",
+			"ENABLED":                    "true",
+			"USERS":                      "ankara,istanbul",
+			"POSTGRES_ENABLED":           "true",
+			"POSTGRES_PORT":              "5432",
+			"POSTGRES_HOSTS":             "192.168.2.1,192.168.2.2,192.168.2.3",
+			"POSTGRES_DBNAME":            "configdb",
+			"POSTGRES_AVAILABILITYRATIO": "8.23",
+			"POSTGRES_FOO":               "8.23,9.12,11,90",
+		}
+	case "CamelCaseServer":
+		env = map[string]string{
+			"ACCESS_KEY":         "123456",
+			"NORMAL":             "normal",
+			"DB_NAME":            "configdb",
+			"AVAILABILITY_RATIO": "8.23",
+		}
 	}
 
 	if prefix == "" {

--- a/flag.go
+++ b/flag.go
@@ -57,7 +57,7 @@ func (f *FlagLoader) Load(s interface{}) error {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 		flagSet.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nGenerated environment variables:\n")
-		e := &EnvironmentLoader{f.EnvPrefix}
+		e := &EnvironmentLoader{Prefix: f.EnvPrefix}
 		e.PrintEnvs(s)
 		fmt.Println("")
 	}

--- a/flag.go
+++ b/flag.go
@@ -57,7 +57,10 @@ func (f *FlagLoader) Load(s interface{}) error {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
 		flagSet.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nGenerated environment variables:\n")
-		e := &EnvironmentLoader{Prefix: f.EnvPrefix}
+		e := &EnvironmentLoader{
+			Prefix:    f.EnvPrefix,
+			CamelCase: f.CamelCase,
+		}
 		e.PrintEnvs(s)
 		fmt.Println("")
 	}

--- a/flag.go
+++ b/flag.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/fatih/camelcase"
 	"github.com/fatih/structs"
 )
 
@@ -26,6 +27,12 @@ type FlagLoader struct {
 	// has a duplicate field name in the root level of the struct (outer
 	// struct). Use this option only if you know what you do.
 	Flatten bool
+
+	// CamelCase adds a seperator for field names in camelcase form. A
+	// fieldname of "AccessKey" would generate a flag name "--accesskey". If
+	// CamelCase is enabled, the flag name will be generated in the form of
+	// "--access-key"
+	CamelCase bool
 
 	// EnvPrefix is just a placeholder to print the correct usages when an
 	// EnvLoader is used
@@ -67,6 +74,10 @@ func (f *FlagLoader) Load(s interface{}) error {
 // nested struct is detected, a flag for each field of that nested struct is
 // generated too.
 func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field *structs.Field) error {
+	if f.CamelCase {
+		fieldName = strings.Join(camelcase.Split(fieldName), "-")
+	}
+
 	switch field.Kind() {
 	case reflect.Struct:
 		for _, ff := range field.Fields() {

--- a/flag_test.go
+++ b/flag_test.go
@@ -62,6 +62,25 @@ func TestFlattenFlags(t *testing.T) {
 	testFlattenedStruct(t, s, getDefaultServer())
 }
 
+func TestCamelcaseFlags(t *testing.T) {
+	m := FlagLoader{
+		CamelCase: true,
+	}
+	s := &CamelCaseServer{}
+	structName := structs.Name(s)
+
+	// get flags
+	args := getFlags(t, structName, "")
+
+	m.Args = args[1:]
+
+	if err := m.Load(s); err != nil {
+		t.Error(err)
+	}
+
+	testCamelcaseStruct(t, s, getDefaultCamelCaseServer())
+}
+
 // getFlags returns a slice of arguments that can be passed to flag.Parse()
 func getFlags(t *testing.T, structName, prefix string) []string {
 	if structName == "" {
@@ -89,6 +108,13 @@ func getFlags(t *testing.T, structName, prefix string) []string {
 			"--hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"--dbname":            "configdb",
 			"--availabilityratio": "8.23",
+		}
+	case "CamelCaseServer":
+		flags = map[string]string{
+			"--access-key":         "123456",
+			"--normal":             "normal",
+			"--db-name":            "configdb",
+			"--availability-ratio": "8.23",
 		}
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -81,6 +81,25 @@ func TestCamelcaseFlags(t *testing.T) {
 	testCamelcaseStruct(t, s, getDefaultCamelCaseServer())
 }
 
+func TestFlattenAndCamelCaseFlags(t *testing.T) {
+	m := FlagLoader{
+		Flatten:   true,
+		CamelCase: true,
+	}
+	s := &FlattenedServer{}
+
+	// get flags
+	args := getFlags(t, "FlattenedCamelCaseServer", "")
+
+	m.Args = args[1:]
+
+	if err := m.Load(s); err != nil {
+		t.Error(err)
+	}
+
+	testFlattenedStruct(t, s, getDefaultServer())
+}
+
 // getFlags returns a slice of arguments that can be passed to flag.Parse()
 func getFlags(t *testing.T, structName, prefix string) []string {
 	if structName == "" {
@@ -108,6 +127,14 @@ func getFlags(t *testing.T, structName, prefix string) []string {
 			"--hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"--dbname":            "configdb",
 			"--availabilityratio": "8.23",
+		}
+	case "FlattenedCamelCaseServer":
+		flags = map[string]string{
+			"--enabled":            "",
+			"--port":               "5432",
+			"--hosts":              "192.168.2.1,192.168.2.2,192.168.2.3",
+			"--db-name":            "configdb",
+			"--availability-ratio": "8.23",
 		}
 	case "CamelCaseServer":
 		flags = map[string]string{

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -25,6 +25,13 @@ type FlattenedServer struct {
 	Postgres Postgres
 }
 
+type CamelCaseServer struct {
+	AccessKey         string
+	Normal            string
+	DBName            string `default:"configdb"`
+	AvailabilityRatio float64
+}
+
 var (
 	testTOML = "testdata/config.toml"
 	testJSON = "testdata/config.json"
@@ -43,6 +50,15 @@ func getDefaultServer() *Server {
 			DBName:            "configdb",
 			AvailabilityRatio: 8.23,
 		},
+	}
+}
+
+func getDefaultCamelCaseServer() *CamelCaseServer {
+	return &CamelCaseServer{
+		AccessKey:         "123456",
+		Normal:            "normal",
+		DBName:            "configdb",
+		AvailabilityRatio: 8.23,
 	}
 }
 
@@ -162,4 +178,23 @@ func testFlattenedStruct(t *testing.T, s *FlattenedServer, d *Server) {
 			t.Fatalf("Hosts number %d is wrong: %v, want: %v", i, s.Postgres.Hosts[i], host)
 		}
 	}
+}
+
+func testCamelcaseStruct(t *testing.T, s *CamelCaseServer, d *CamelCaseServer) {
+	if s.AccessKey != d.AccessKey {
+		t.Errorf("AccessKey is wrong: %s, want: %s", s.AccessKey, d.AccessKey)
+	}
+
+	if s.Normal != d.Normal {
+		t.Errorf("Normal is wrong: %s, want: %s", s.Normal, d.Normal)
+	}
+
+	if s.DBName != d.DBName {
+		t.Errorf("DBName is wrong: %s, want: %s", s.DBName, d.DBName)
+	}
+
+	if s.AvailabilityRatio != d.AvailabilityRatio {
+		t.Errorf("AvailabilityRatio is wrong: %f, want: %f", s.AvailabilityRatio, d.AvailabilityRatio)
+	}
+
 }


### PR DESCRIPTION
This PR introduces a new `CamelCase` feature for both Env and Flag loaders. Once enabled it allows us to create flags of `--access-key` instead of `--accesskey`, and envrionment variables of `ACCESS_KEY` instead of `ACCESSKEY`. This is backwards compatible with the current API.