### PR TITLE
flag: fix panicing for unexported fields in structs

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -110,7 +110,10 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 			fieldName = f.Prefix + "-" + fieldName
 		}
 
-		flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsage(fieldName))
+		// we only can get the value from expored fields, unexported fields panics
+		if field.IsExported() {
+			flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsage(fieldName))
+		}
 	}
 
 	return nil

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -4,11 +4,12 @@ import "testing"
 
 type (
 	Server struct {
-		Name     string `required:"true"`
-		Port     int    `default:"6060"`
-		Enabled  bool
-		Users    []string
-		Postgres Postgres
+		Name       string `required:"true"`
+		Port       int    `default:"6060"`
+		Enabled    bool
+		Users      []string
+		Postgres   Postgres
+		unexported string
 	}
 
 	// Postgres holds Postgresql database related configuration
@@ -18,6 +19,7 @@ type (
 		Hosts             []string `required:"true"`
 		DBName            string   `default:"configdb"`
 		AvailabilityRatio float64
+		unexported        string
 	}
 )
 


### PR DESCRIPTION
If a config had an unexported field it would just panic, example:

```go
type GCE struct {
	ProjectID   string
	AccountFile string
	Region      string

	svc *compute.ImagesService
}
```

Trying to load this would cause multiconfig to panic, because svc is
unexported.