### PR TITLE
Allow configuration to be specified as an io.Reader

### DIFF
--- a/file.go
+++ b/file.go
@@ -3,7 +3,7 @@ package multiconfig
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -19,19 +19,28 @@ var (
 )
 
 // TOMLLoader satisifies the loader interface. It loads the configuration from
-// the given toml file.
+// the given toml file or Reader
 type TOMLLoader struct {
-	Path string
+	Path   string
+	Reader io.Reader
 }
 
 // Load loads the source into the config defined by struct s
+// Defaults to using the Reader if provided, otherwise tries to read from the
+// file
 func (t *TOMLLoader) Load(s interface{}) error {
-	filePath, err := getConfigPath(t.Path)
-	if err != nil {
-		return err
+	var r io.Reader
+	if t.Reader != nil {
+		r = t.Reader
+	} else {
+		file, err := getConfig(t.Path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		r = file
 	}
-
-	if _, err := toml.DecodeFile(filePath, s); err != nil {
+	if _, err := toml.DecodeReader(r, s); err != nil {
 		return err
 	}
 
@@ -39,47 +48,52 @@ func (t *TOMLLoader) Load(s interface{}) error {
 }
 
 // JSONLoader satisifies the loader interface. It loads the configuration from
-// the given json file.
+// the given json file or Reader
 type JSONLoader struct {
-	Path string
+	Path   string
+	Reader io.Reader
 }
 
 // Load loads the source into the config defined by struct s
+// Defaults to using the Reader if provided, otherwise tries to read from the
+// file
 func (j *JSONLoader) Load(s interface{}) error {
-	filePath, err := getConfigPath(j.Path)
-	if err != nil {
-		return err
+	var r io.Reader
+	if j.Reader != nil {
+		r = j.Reader
+	} else {
+		file, err := getConfig(j.Path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		r = file
 	}
 
-	file, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return err
-	}
-
-	return json.Unmarshal(file, s)
+	return json.NewDecoder(r).Decode(s)
 }
 
-func getConfigPath(path string) (string, error) {
+func getConfig(path string) (*os.File, error) {
 	if path == "" {
-		return "", ErrPathNotSet
+		return nil, ErrPathNotSet
 	}
 
 	pwd, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	configPath := filepath.Join(pwd, path)
 
 	// check if file with combined path is exists(relative path)
 	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
-		return configPath, nil
+		return os.Open(configPath)
 	}
 
 	// check if file is exists it self
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		return path, nil
+		return os.Open(path)
 	}
 
-	return "", ErrFileNotFound
+	return nil, ErrFileNotFound
 }

--- a/file.go
+++ b/file.go
@@ -92,10 +92,9 @@ func getConfig(path string) (*os.File, error) {
 		return os.Open(configPath)
 	}
 
-	// check if file is exists it self
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		return os.Open(path)
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, ErrFileNotFound
 	}
-
-	return nil, ErrFileNotFound
+	return f, err
 }

--- a/file_test.go
+++ b/file_test.go
@@ -1,6 +1,9 @@
 package multiconfig
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestToml(t *testing.T) {
 	m := NewWithPath(testTOML)
@@ -13,11 +16,43 @@ func TestToml(t *testing.T) {
 	testStruct(t, s, getDefaultServer())
 }
 
+func TestToml_Reader(t *testing.T) {
+	f, err := os.Open(testTOML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	l := MultiLoader(&TagLoader{}, &TOMLLoader{Reader: f})
+	s := &Server{}
+	if err := l.Load(s); err != nil {
+		t.Error(err)
+	}
+
+	testStruct(t, s, getDefaultServer())
+}
+
 func TestJSON(t *testing.T) {
 	m := NewWithPath(testJSON)
 
 	s := &Server{}
 	if err := m.Load(s); err != nil {
+		t.Error(err)
+	}
+
+	testStruct(t, s, getDefaultServer())
+}
+
+func TestJSON_Reader(t *testing.T) {
+	f, err := os.Open(testJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	l := MultiLoader(&TagLoader{}, &JSONLoader{Reader: f})
+	s := &Server{}
+	if err := l.Load(s); err != nil {
 		t.Error(err)
 	}
 

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -1,5 +1,5 @@
 Name              = "koding"
-Enabled           = false
+Enabled           = true
 Users             = ["ankara", "istanbul"]
 
 [Postgres]


### PR DESCRIPTION
Rather than just a path on disk

This allows for things like reading the configuration from STDIN

First of all, awesome package! I like that you put composability first.

I'm not super crazy about the implementation of this PR, but the existing structs are very centered around reading from files so I'm not sure what the best way to handle adding something like this is. If you are open to changing the interface of the package, I'd recommend centering the API around `io.Reader`s and adding helper functions for dealing with files.

Anyway, I just wanted to get your thoughts about adding something like this to the package.