### PR TITLE
include field name in unsupported type error message

### DIFF
--- a/multiconfig.go
+++ b/multiconfig.go
@@ -155,7 +155,7 @@ func fieldSet(field *structs.Field, v string) error {
 			return err
 		}
 	default:
-		return fmt.Errorf("multiconfig: not supported type: %s", field.Kind())
+		return fmt.Errorf("multiconfig: field '%s' has unsupported type: %s", field.Name(), field.Kind())
 	}
 
 	return nil


### PR DESCRIPTION
I was retrofitting multiconfig into an existing project today and run up against a few unsupported types. I was finding that error messages such as:

```
multiconfig: not supported type: int64
```

This left me scratching my head on what field was failing (it was indirectly an int64, a time.Duration).


This patch adds the failing field name to the error message, which produces messages such as:

```
multiconfig: field 'UploadInterval' has unsupported type: int64
```

Thanks for a great library!
