### PR TITLE
check configPath IsAbs not join the pwd

### DIFF
--- a/file.go
+++ b/file.go
@@ -85,7 +85,10 @@ func getConfig(path string) (*os.File, error) {
 		return nil, err
 	}
 
-	configPath := filepath.Join(pwd, path)
+	configPath := path
+	if !filepath.IsAbs(path) {
+		configPath = filepath.Join(pwd, path)
+	}
 
 	// check if file with combined path is exists(relative path)
 	if _, err := os.Stat(configPath); !os.IsNotExist(err) {


### PR DESCRIPTION
run in windows got a wrong path 
if I input  c:\kt\conf\a.toml
it get c:\kt\c:\kt\conf\a.toml
go I check  configPath IsAbs before join