### PR TITLE
Part of #23 - allow flagloader to set optional function to set flag usage

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -41,10 +41,10 @@ type FlagLoader struct {
 	// Args defines a custom argument list. If nil, os.Args[1:] is used.
 	Args []string
 
-	// UsageFunc an optional function that is called to set a flag.Usage value
+	// FlagUsageFunc an optional function that is called to set a flag.Usage value
 	// The input is the raw flag name, and the output should be a string
 	// that will used in passed into the flag for Usage.
-	UsageFunc func(name string) string
+	FlagUsageFunc func(name string) string
 
 	// only exists for testing.  This is the raw flagset that is to parse
 	flagSet *flag.FlagSet
@@ -122,11 +122,11 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 		// we only can get the value from expored fields, unexported fields panics
 		if field.IsExported() {
 			// use built-in or custom flag usage message
-			flagUsageFn := flagUsage
-			if f.UsageFunc != nil {
-				flagUsageFn = f.UsageFunc
+			flagUsageFunc := flagUsageDefault
+			if f.FlagUsageFunc != nil {
+				flagUsageFunc = f.FlagUsageFunc
 			}
-			flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsageFn(fieldName))
+			flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsageFunc(fieldName))
 		}
 	}
 
@@ -166,6 +166,8 @@ func (f *fieldValue) IsBoolFlag() bool {
 	return false
 }
 
-func flagUsage(name string) string { return fmt.Sprintf("Change value of %s.", name) }
+// flagUsageDefault is the default "FlagUsageFunc" use in filling out
+// the usage of a flag.
+func flagUsageDefault(name string) string { return fmt.Sprintf("Change value of %s.", name) }
 
 func flagName(name string) string { return strings.ToLower(name) }

--- a/flag.go
+++ b/flag.go
@@ -42,8 +42,8 @@ type FlagLoader struct {
 	Args []string
 
 	// UsageFunc an optional function that is called to set a flag.Usage value
-	//  The input is the raw flag name, and the output should be a string
-	//  that will used in passed into the flag for Usage.
+	// The input is the raw flag name, and the output should be a string
+	// that will used in passed into the flag for Usage.
 	UsageFunc func(name string) string
 
 	// only exists for testing.  This is the raw flagset that is to parse

--- a/flag.go
+++ b/flag.go
@@ -59,7 +59,7 @@ func (f *FlagLoader) Load(s interface{}) error {
 	f.flagSet = flagSet
 
 	for _, field := range strct.Fields() {
-		f.processField(flagSet, field.Name(), field)
+		f.processField(field.Name(), field)
 	}
 
 	flagSet.Usage = func() {
@@ -85,7 +85,7 @@ func (f *FlagLoader) Load(s interface{}) error {
 // processField generates a flag based on the given field and fieldName. If a
 // nested struct is detected, a flag for each field of that nested struct is
 // generated too.
-func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field *structs.Field) error {
+func (f *FlagLoader) processField(fieldName string, field *structs.Field) error {
 	if f.CamelCase {
 		fieldName = strings.Join(camelcase.Split(fieldName), "-")
 	}
@@ -99,7 +99,7 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 				// first check if it's set or not, because if we have duplicate
 				// we don't want to break the flag. Panic by giving a readable
 				// output
-				flagSet.VisitAll(func(fl *flag.Flag) {
+				f.flagSet.VisitAll(func(fl *flag.Flag) {
 					if strings.ToLower(ff.Name()) == fl.Name {
 						// already defined
 						panic(fmt.Sprintf("flag '%s' is already defined in outer struct", fl.Name))
@@ -109,7 +109,7 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 				flagName = ff.Name()
 			}
 
-			if err := f.processField(flagSet, flagName, ff); err != nil {
+			if err := f.processField(flagName, ff); err != nil {
 				return err
 			}
 		}
@@ -126,7 +126,7 @@ func (f *FlagLoader) processField(flagSet *flag.FlagSet, fieldName string, field
 			if f.FlagUsageFunc != nil {
 				flagUsageFunc = f.FlagUsageFunc
 			}
-			flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsageFunc(fieldName))
+			f.flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsageFunc(fieldName))
 		}
 	}
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -104,7 +104,7 @@ func TestCustomUsageFunc(t *testing.T) {
 		Foobar string
 	}{}
 	m := FlagLoader{
-		UsageFunc: (func(s string) string { return usageMsg }),
+		FlagUsageFunc: (func(s string) string { return usageMsg }),
 	}
 	err := m.Load(&strt)
 

--- a/flag_test.go
+++ b/flag_test.go
@@ -96,8 +96,28 @@ func TestFlattenAndCamelCaseFlags(t *testing.T) {
 	if err := m.Load(s); err != nil {
 		t.Error(err)
 	}
+}
 
-	testFlattenedStruct(t, s, getDefaultServer())
+func TestCustomUsageFunc(t *testing.T) {
+	const usageMsg = "foobar help"
+	strt := struct {
+		Foobar string
+	}{}
+	m := FlagLoader{
+		UsageFunc: (func(s string) string { return usageMsg }),
+	}
+	err := m.Load(&strt)
+
+	if err != nil {
+		t.Fatalf("Unable to load struct: %s", err)
+	}
+	f := m.flagSet.Lookup("foobar")
+	if f == nil {
+		t.Fatalf("Flag foobar is not set")
+	}
+	if f.Usage != usageMsg {
+		t.Fatalf("usage message was %q, expected %q", f.Usage, usageMsg)
+	}
 }
 
 // getFlags returns a slice of arguments that can be passed to flag.Parse()


### PR DESCRIPTION
@fatih   This allow people to have function to set flag default Usage messages.  To write a test I had to save the temporary `FlagSet` that is created (as a private field in `FlagLoader`).  If you don't like this, we can either just delete the test (not great) or figure out another way to emit the usage and capture stdout/stderr  (really gross).

merge, comment or suggestions all welcome!

n

