### PR TITLE
allow the usage defined on tag

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -127,16 +127,24 @@ func (f *FlagLoader) processField(fieldName string, field *structs.Field) error 
 
 		// we only can get the value from expored fields, unexported fields panics
 		if field.IsExported() {
-			// use built-in or custom flag usage message
-			flagUsageFunc := flagUsageDefault
-			if f.FlagUsageFunc != nil {
-				flagUsageFunc = f.FlagUsageFunc
-			}
-			f.flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsageFunc(fieldName))
+			f.flagSet.Var(newFieldValue(field), flagName(fieldName), f.flagUsage(fieldName, field))
 		}
 	}
 
 	return nil
+}
+
+func (f *FlagLoader) flagUsage(fieldName string, field *structs.Field) string {
+	if f.FlagUsageFunc != nil {
+		return f.FlagUsageFunc(fieldName)
+	}
+
+	usage := field.Tag("flagUsage")
+	if usage != "" {
+		return usage
+	}
+
+	return fmt.Sprintf("Change value of %s.", fieldName)
 }
 
 // fieldValue satisfies the flag.Value and flag.Getter interfaces
@@ -179,9 +187,5 @@ func (f *fieldValue) IsZero() bool {
 func (f *fieldValue) IsBoolFlag() bool {
 	return f.field.Kind() == reflect.Bool
 }
-
-// flagUsageDefault is the default "FlagUsageFunc" use in filling out
-// the usage of a flag.
-func flagUsageDefault(name string) string { return fmt.Sprintf("Change value of %s.", name) }
 
 func flagName(name string) string { return strings.ToLower(name) }

--- a/flag_test.go
+++ b/flag_test.go
@@ -120,6 +120,26 @@ func TestCustomUsageFunc(t *testing.T) {
 	}
 }
 
+func TestCustomUsageTag(t *testing.T) {
+	const usageMsg = "foobar help"
+	strt := struct {
+		Foobar string `flagUsage:"foobar help"`
+	}{}
+	m := FlagLoader{}
+	err := m.Load(&strt)
+
+	if err != nil {
+		t.Fatalf("Unable to load struct: %s", err)
+	}
+	f := m.flagSet.Lookup("foobar")
+	if f == nil {
+		t.Fatalf("Flag foobar is not set")
+	}
+	if f.Usage != usageMsg {
+		t.Fatalf("usage message was %q, expected %q", f.Usage, usageMsg)
+	}
+}
+
 // getFlags returns a slice of arguments that can be passed to flag.Parse()
 func getFlags(t *testing.T, structName, prefix string) []string {
 	if structName == "" {


### PR DESCRIPTION
This PR allows the flag usage defined on tag.
Such as:
```
type Foo struct {
    Foobar string `flagUsage:"foobar help"`
}
```
