### PR TITLE
Ignore test flags (issue #40)

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -80,10 +80,11 @@ func (f *FlagLoader) Load(s interface{}) error {
 		fmt.Println("")
 	}
 
-	args := os.Args[1:]
+	args := filterArgs(os.Args[1:])
 	if f.Args != nil {
 		args = f.Args
 	}
+
 
 	return flagSet.Parse(args)
 }
@@ -94,7 +95,6 @@ func (f *FlagLoader) Load(s interface{}) error {
 func (f *FlagLoader) processField(fieldName string, field *structs.Field) error {
 	if f.CamelCase {
 		fieldName = strings.Join(camelcase.Split(fieldName), "-")
-		fieldName = strings.Replace(fieldName, "---", "-", -1)
 	}
 
 	switch field.Kind() {
@@ -128,29 +128,36 @@ func (f *FlagLoader) processField(fieldName string, field *structs.Field) error 
 
 		// we only can get the value from expored fields, unexported fields panics
 		if field.IsExported() {
-			f.flagSet.Var(newFieldValue(field), flagName(fieldName), f.flagUsage(fieldName, field))
+			// use built-in or custom flag usage message
+			flagUsageFunc := flagUsageDefault
+			if f.FlagUsageFunc != nil {
+				flagUsageFunc = f.FlagUsageFunc
+			}
+			f.flagSet.Var(newFieldValue(field), flagName(fieldName), flagUsageFunc(fieldName))
 		}
 	}
 
 	return nil
 }
 
-func (f *FlagLoader) flagUsage(fieldName string, field *structs.Field) string {
-	if f.FlagUsageFunc != nil {
-		return f.FlagUsageFunc(fieldName)
-	}
-
-	usage := field.Tag("flagUsage")
-	if usage != "" {
-		return usage
-	}
-
-	return fmt.Sprintf("Change value of %s.", fieldName)
-}
-
 // fieldValue satisfies the flag.Value and flag.Getter interfaces
 type fieldValue struct {
 	field *structs.Field
+}
+
+func filterArgs(args []string) []string {
+	r := []string{}
+	for i := 0; i < len(args); i++ {
+		if strings.Index(args[i], "test") >= 0 {
+			if i + 1 < len(args) && strings.Index(args[i + 1], "-") == -1 {
+				i++
+			}
+			i++
+		} else {
+			r = append(r, args[i])
+		}
+	}
+	return r
 }
 
 func newFieldValue(f *structs.Field) *fieldValue {
@@ -188,5 +195,9 @@ func (f *fieldValue) IsZero() bool {
 func (f *fieldValue) IsBoolFlag() bool {
 	return f.field.Kind() == reflect.Bool
 }
+
+// flagUsageDefault is the default "FlagUsageFunc" use in filling out
+// the usage of a flag.
+func flagUsageDefault(name string) string { return fmt.Sprintf("Change value of %s.", name) }
 
 func flagName(name string) string { return strings.ToLower(name) }


### PR DESCRIPTION
Using go test -v ... shows the help message from multiconfig. Flags starting with test are ignored (and the possible parameter to the flag).