### PR TITLE
fix nested struct conflict & should not flatten nested field

### DIFF
--- a/env_test.go
+++ b/env_test.go
@@ -90,11 +90,13 @@ func setEnvVars(t *testing.T, structName, prefix string) {
 			"INTERVAL":                   "10s",
 			"ID":                         "1234567890",
 			"LABELS":                     "123,456",
+			"LOG_FILE":                   "/var/log/global.log",
 			"POSTGRES_ENABLED":           "true",
 			"POSTGRES_PORT":              "5432",
 			"POSTGRES_HOSTS":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"POSTGRES_DBNAME":            "configdb",
 			"POSTGRES_AVAILABILITYRATIO": "8.23",
+			"POSTGRES_LOG_FILE":          "/var/log/postgres.log",
 			"POSTGRES_FOO":               "8.23,9.12,11,90",
 		}
 	case "CamelCaseServer":
@@ -112,6 +114,7 @@ func setEnvVars(t *testing.T, structName, prefix string) {
 			"HOSTS":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"DBNAME":            "configdb",
 			"AVAILABILITYRATIO": "8.23",
+			"LOG_FILE":          "/var/log/postgres.log",
 			"FOO":               "8.23,9.12,11,90",
 		}
 	}

--- a/flag.go
+++ b/flag.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fatih/camelcase"
 	"github.com/fatih/structs"
+	"github.com/kballard/go-shellquote"
 )
 
 // FlagLoader satisfies the loader interface. It creates on the fly flags based
@@ -44,8 +45,11 @@ type FlagLoader struct {
 	// By default it's flag.ContinueOnError.
 	ErrorHandling flag.ErrorHandling
 
-	// Args defines a custom argument list. If nil, os.Args[1:] is used.
+	// Args defines a custom argument list. If nil and RawArgs is empty, os.Args[1:] is used.
 	Args []string
+
+	// RawArgs define a custom shell command line args, When not empty and Args is nil.
+	RawArgs string
 
 	// FlagUsageFunc an optional function that is called to set a flag.Usage value
 	// The input is the raw flag name, and the output should be a string
@@ -83,6 +87,12 @@ func (f *FlagLoader) Load(s interface{}) error {
 	args := filterArgs(os.Args[1:])
 	if f.Args != nil {
 		args = f.Args
+	} else if f.RawArgs != "" {
+		var err error
+		args, err = shellquote.Split(f.RawArgs)
+		if err != nil {
+			return err
+		}
 	}
 
 	return flagSet.Parse(args)

--- a/flag_test.go
+++ b/flag_test.go
@@ -201,11 +201,13 @@ func getFlags(t *testing.T, structName, prefix string) []string {
 			"-interval":                   "10s",
 			"-id":                         "1234567890",
 			"-labels":                     "123,456",
+			"-log-file":                   "/var/log/global.log",
 			"-postgres-enabled":           "",
 			"-postgres-port":              "5432",
 			"-postgres-hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"-postgres-dbname":            "configdb",
 			"-postgres-availabilityratio": "8.23",
+			"-postgres-log-file":          "/var/log/postgres.log",
 		}
 	case "FlattenedServer":
 		flags = map[string]string{
@@ -214,6 +216,7 @@ func getFlags(t *testing.T, structName, prefix string) []string {
 			"--hosts":             "192.168.2.1,192.168.2.2,192.168.2.3",
 			"--dbname":            "configdb",
 			"--availabilityratio": "8.23",
+			"-log-file":           "/var/log/postgres.log",
 		}
 	case "FlattenedCamelCaseServer":
 		flags = map[string]string{

--- a/multiconfig.go
+++ b/multiconfig.go
@@ -181,6 +181,20 @@ func fieldSet(field *structs.Field, v string) error {
 			if err := field.Set(list); err != nil {
 				return err
 			}
+		case []float32:
+			var list []float32
+			for _, in := range strings.Split(v, ",") {
+				i, err := strconv.ParseFloat(in, 32)
+				if err != nil {
+					return err
+				}
+
+				list = append(list, float32(i))
+			}
+
+			if err := field.Set(list); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("multiconfig: field '%s' of type slice is unsupported: %s (%T)",
 				field.Name(), field.Kind(), t)

--- a/multiconfig.go
+++ b/multiconfig.go
@@ -194,6 +194,15 @@ func fieldSet(field *structs.Field, v string) error {
 		if err := field.Set(f); err != nil {
 			return err
 		}
+	case reflect.Float32:
+		f, err := strconv.ParseFloat(v, 32)
+		if err != nil {
+			return err
+		}
+
+		if err := field.Set(float32(f)); err != nil {
+			return err
+		}
 	case reflect.Int64:
 		switch t := field.Value().(type) {
 		case time.Duration:

--- a/multiconfig_test.go
+++ b/multiconfig_test.go
@@ -13,6 +13,7 @@ type (
 		Labels     []int
 		Enabled    bool
 		Users      []string
+		Log        Log
 		Postgres   Postgres
 		unexported string
 		Interval   time.Duration
@@ -25,12 +26,17 @@ type (
 		Hosts             []string `required:"true"`
 		DBName            string   `default:"configdb"`
 		AvailabilityRatio float64
+		Log               Log
 		unexported        string
 	}
 
 	TaggedServer struct {
 		Name     string `required:"true"`
 		Postgres `structs:",flatten"`
+	}
+
+	Log struct {
+		File string
 	}
 )
 
@@ -60,12 +66,14 @@ func getDefaultServer() *Server {
 		Labels:   []int{123, 456},
 		Users:    []string{"ankara", "istanbul"},
 		Interval: 10 * time.Second,
+		Log:      Log{File: "/var/log/global.log"},
 		Postgres: Postgres{
 			Enabled:           true,
 			Port:              5432,
 			Hosts:             []string{"192.168.2.1", "192.168.2.2", "192.168.2.3"},
 			DBName:            "configdb",
 			AvailabilityRatio: 8.23,
+			Log:               Log{File: "/var/log/postgres.log"},
 		},
 	}
 }
@@ -154,6 +162,10 @@ func testStruct(t *testing.T, s *Server, d *Server) {
 		}
 	}
 
+	if s.Log.File != d.Log.File {
+		t.Errorf("Log value is wrong: %s, want: %s", s.Log.File, d.Log.File)
+	}
+
 	testPostgres(t, s.Postgres, d.Postgres)
 }
 
@@ -178,6 +190,10 @@ func testPostgres(t *testing.T, s Postgres, d Postgres) {
 
 	if s.AvailabilityRatio != d.AvailabilityRatio {
 		t.Errorf("AvailabilityRatio is wrong: %f, want: %f", s.AvailabilityRatio, d.AvailabilityRatio)
+	}
+
+	if s.Log.File != d.Log.File {
+		t.Errorf("Postgres Log value is wrong: %s, want: %s", s.Log.File, d.Log.File)
 	}
 
 	if len(s.Hosts) != len(d.Hosts) {

--- a/testdata/config.json
+++ b/testdata/config.json
@@ -11,6 +11,9 @@
     "ankara",
     "istanbul"
   ],
+  "Log": {
+    "File": "/var/log/global.log"
+  },
   "Postgres": {
     "Enabled": true,
     "Port": 5432,
@@ -19,6 +22,9 @@
       "192.168.2.2",
       "192.168.2.3"
     ],
-    "AvailabilityRatio": 8.23
+    "AvailabilityRatio": 8.23,
+    "Log": {
+      "File": "/var/log/postgres.log"
+    }
   }
 }

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -1,12 +1,16 @@
 Name              = "koding"
 Enabled           = true
 Users             = ["ankara", "istanbul"]
-Interval 	  = 10000000000
-ID       	  = 1234567890
-Labels       	  = [123,456]
+Interval          = 10000000000
+ID                = 1234567890
+Labels            = [123,456]
+[Log]
+File              = "/var/log/global.log"
 
 [Postgres]
 Enabled           = true
 Port              = 5432
 Hosts             = ["192.168.2.1", "192.168.2.2", "192.168.2.3"]
 AvailabilityRatio = 8.23
+    [Postgres.Log]
+    File = "/var/log/postgres.log"

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -16,6 +16,9 @@ labels:
     - 123
     - 456
 
+log:
+    file: /var/log/global.log
+
 # postgres configure
 postgres:
     enabled: true
@@ -25,4 +28,6 @@ postgres:
         - 192.168.2.2
         - 192.168.2.3
     availabilityratio:  8.23
+    log:
+        file: /var/log/postgres.log
 


### PR DESCRIPTION
I suffer an error:`panic: ConfigTOML flag redefined: log-filename` in such a toml file:

```
[Log]
Filename = 'file1'

[Kafka]
    [Kafka.Log]
    Filename = 'file2'
```

The flag constructor doesn't parse `-kafka-log-filename`.